### PR TITLE
Feature add background service

### DIFF
--- a/Trimly.Core.Application/AddApplication.cs
+++ b/Trimly.Core.Application/AddApplication.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Trimly.Core.Application.Interfaces.Service;
 using Trimly.Core.Application.Services;
+using Trimly.Core.Domain.Utils;
 
 namespace Trimly.Core.Application
 {
@@ -13,6 +14,7 @@ namespace Trimly.Core.Application
             services.AddScoped<IServicesService, ServicesService>();
             services.AddScoped<IReviewService, ReviewService>();
             services.AddScoped<ISchedulesService, SchedulesService>();
+            services.AddSingleton<AppointmentQueue>();
             return services;
         }
     }

--- a/Trimly.Core.Domain/Utils/AppointmentQueue.cs
+++ b/Trimly.Core.Domain/Utils/AppointmentQueue.cs
@@ -1,0 +1,26 @@
+using System.Collections.Concurrent;
+
+namespace Trimly.Core.Domain.Utils;
+
+public class AppointmentQueue
+{
+    private readonly ConcurrentQueue<Guid> _queue = new();
+    private readonly SemaphoreSlim _signal = new(0);
+
+    public void Enqueue(Guid appointmentId)
+    {
+        _queue.Enqueue(appointmentId);
+        _signal.Release(); // Notify that there is a new ID in the queue
+    }
+    
+    public async Task<Guid?> DequeueAsync(CancellationToken cancellationToken)
+    {
+        await _signal.WaitAsync(cancellationToken);
+
+        if (_queue.TryDequeue(out var appointmentId))
+        {
+            return appointmentId;
+        }
+        return null;
+    }
+}

--- a/Trimly/BackgroundService/ConfirmAppointmentBackgroundService.cs
+++ b/Trimly/BackgroundService/ConfirmAppointmentBackgroundService.cs
@@ -1,0 +1,46 @@
+using Trimly.Core.Application.Interfaces.Service;
+using Trimly.Core.Domain.Utils;
+
+namespace Trimly.Presentation.BackgroundService;
+
+public class ConfirmAppointmentBackgroundService : Microsoft.Extensions.Hosting.BackgroundService
+{
+    private readonly IAppointmentService _appointmentService;
+    private readonly ILogger<ConfirmAppointmentBackgroundService> _logger;
+    private readonly AppointmentQueue _queue;
+    private readonly IServiceScopeFactory _serviceScopeFactory;
+
+    public ConfirmAppointmentBackgroundService(
+        IAppointmentService service, 
+        ILogger<ConfirmAppointmentBackgroundService> logger,
+        AppointmentQueue queue,
+        IServiceScopeFactory serviceScopeFactory)
+    {
+        _appointmentService = service;
+        _logger = logger;
+        _queue = queue;
+        _serviceScopeFactory = serviceScopeFactory;
+    }
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("ConfirmAppointmentBackgroundService start.");
+        
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var appointmentId = await _queue.DequeueAsync(stoppingToken);
+            if (appointmentId == null) continue;
+
+            using (var scope = _serviceScopeFactory.CreateScope())
+            {
+                var appointmentService = scope.ServiceProvider.GetRequiredService<IAppointmentService>();
+
+                _logger.LogInformation("Processing automatic confirmation for appointment: {AppointmentId}", appointmentId);
+
+                await appointmentService.ConfirmAppointmentAutomaticallyAsync(appointmentId.Value, stoppingToken);
+            }
+        }
+
+        _logger.LogInformation("ConfirmAppointmentBackgroundService stop.");
+        
+    }
+}

--- a/Trimly/Program.cs
+++ b/Trimly/Program.cs
@@ -3,6 +3,7 @@ using Trimly.Infrastructure.Persistence;
 using Trimly.Infrastructure.Shared;
 using Trimly.Infrastructure.Identity;
 using Trimly.Infrastructure.Identity.Seeds;
+using Trimly.Presentation.BackgroundService;
 
 try
 {
@@ -15,7 +16,7 @@ try
     // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
     builder.Services.AddEndpointsApiExplorer();
     builder.Services.AddSwaggerGen();
-
+    builder.Services.AddHostedService<ConfirmAppointmentBackgroundService>();
     var config = builder.Configuration;
     builder.Host.UseSerilog((context, loggerConfiguration) =>
     {


### PR DESCRIPTION
# Add Background Service for Automatic Appointment Confirmation

## Description
This PR introduces a background service to handle automatic appointment confirmation asynchronously. Additionally, it improves validation by ensuring that an appointment is only confirmed if it was created more than one hour ago.

## Changes
- Added validation to ensure appointments created within the last hour are confirmed automatically.
- Refactored `ConfirmAppointmentAutomaticallyAsync` to include validation.
- Implemented a background service to process appointment confirmations in the background.
- Added queue handling to manage appointments asynchronously.

## Related Commits
- `refactor: add validation for automatic appointment confirmation`
- `feat: add appointment queue method`
- `feat: add confirm appointment background service`

## Checklist
- [x] Code compiles without errors
- [x] Tests added or updated (if applicable)
- [x] Proper logging added for debugging
- [x] No breaking changes introduced

## Notes
This update enhances performance by offloading appointment confirmations to a background process, reducing API response time and improving user experience.

